### PR TITLE
Add Jupyter Notebook for Calculating Paper Folds to Exceed Mt. Fuji and Celestial Distances

### DIFF
--- a/MtFuji_paper_folding.ipynb
+++ b/MtFuji_paper_folding.ipynb
@@ -1,0 +1,252 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a5acaeb2-3571-4f55-aeee-a73b855ac36a",
+   "metadata": {},
+   "source": [
+    "# [Problem 1] How many times to fold paper to exceed the height of Mt.Fuji?\n",
+    "## Create a program that calculates the minimum number of times to fold the paper required for the thickness to exceed the \"height of Mt. Fuji (3776m)\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 133,
+   "id": "4a367837-ea18-4361-816e-ef09863cd01e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The minimum number of times to fold the paper required for the thickness to exceed the 'height of Mt. Fuji' (3776 m) is 26 times\n"
+     ]
+    }
+   ],
+   "source": [
+    "THICKNESS = 0.00008 # m\n",
+    "HEIGHT_OF_MTFUJI = 3776 # m\n",
+    "n=1\n",
+    "folded_thickness=1\n",
+    "while(folded_thickness<HEIGHT_OF_MTFUJI): # Because we do not know the range or amount of iterations (while)\n",
+    "    folded_thickness=THICKNESS * (2**n)\n",
+    "    n=n+1\n",
+    "folds = n-1 # calculate de minimum number of times\n",
+    "print(f\"The minimum number of times to fold the paper required for the thickness to exceed the 'height of Mt. Fuji' ({HEIGHT_OF_MTFUJI} m) is {count} times\") \n",
+    "#print(folded_thickness)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ef74ba3-3180-43ac-a743-887e00c8cdf1",
+   "metadata": {},
+   "source": [
+    "# [Problem 2] Function corresponding to arbitrary thickness\n",
+    "## Implement a function that, given a height input, would output the minimum number of paper folds required to exceed it.\n",
+    "## Let's make it possible to set the thickness $t_{0}$ before folding as an argument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 150,
+   "id": "aa3e449a-6d92-4409-9f61-74af2bed1b14",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The minimum number of paper folds required to exceed 26 m, is 5368.70912 m\n"
+     ]
+    }
+   ],
+   "source": [
+    "def folds_to_exceed_height(height, thickness=0.00008):\n",
+    "    n=1\n",
+    "    folded_thickness = 1\n",
+    "    while(folded_thickness<height):\n",
+    "        folded_thickness = thickness*(2**n)\n",
+    "        n=n+1\n",
+    "        folds=n-1\n",
+    "    return folds\n",
+    "\n",
+    "#eg:\n",
+    "print (f\"The minimum number of paper folds required to exceed {folds_to_exceed_height(3776,0.00008)} m, is {folded_thickness} m\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88de4e48-e1c9-4576-912a-37a67390b018",
+   "metadata": {},
+   "source": [
+    "# Using this function, calculate how many times you would need to fold a piece of paper to reach the nearest non-sun star.\n",
+    "# The nearest non-sun star is Proxima Centauri, which is about $4.0175 \\times 10^{16}$m away from Earth.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 151,
+   "id": "344d9ebb-e4a3-48fe-bf5e-6e25d92637d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of folds required to reach Proxima Centauri: 69\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Distance to Proxima Centauri\n",
+    "distance_to_proxima_centauri = 4.0175 * 10**16  # meters\n",
+    "\n",
+    "# Calculate the number of folds\n",
+    "num_folds = folds_to_exceed_height(distance_to_proxima_centauri)\n",
+    "\n",
+    "print(f\"Number of folds required to reach Proxima Centauri: {num_folds}\") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc0ded4d-b453-4ec2-8bd9-ccdb78a8ca29",
+   "metadata": {},
+   "source": [
+    "# [Problem 3] Required paper length"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 152,
+   "id": "3d74cd62-0008-42ac-8b2a-a59c4ae0e276",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "def required_paper_length(height, thickness=0.00008):\n",
+    "    t=thickness\n",
+    "    l=((math.pi*t)/6)*(2**n + 4)*(2**n -1)\n",
+    "    return l"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 153,
+   "id": "66f3dc72-5b51-4a42-8a83-cbec17770d90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Then use this to find out the length of paper needed to reach the Moon, Mt. \n",
+    "# Fuji, and the stars closest to the Sun.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 154,
+   "id": "e36cfc2c-bd58-4ccd-9654-8dedf8829cfc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The number of folds : 23\n",
+      "The length of paper needed to reach the Moon is : 754585377082.664 m\n"
+     ]
+    }
+   ],
+   "source": [
+    "# To reach the Moon \n",
+    "# Calculate the number of folds \n",
+    "DISTANCE_TO_MOON_M = 384400/1000 #Km to meters\n",
+    "initial_thickness = 0.00008 # m \n",
+    "num_folds_moon = folds_to_exceed_height(DISTANCE_TO_MOON_M,initial_thickness)\n",
+    "print(f\"The number of folds : {num_folds_moon}\")\n",
+    "#Calculate the required paper length \n",
+    "print(f\"The length of paper needed to reach the Moon is : {required_paper_length(num_folds_moon, initial_thickness)} m\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 155,
+   "id": "9fb117ee-0f60-438f-a160-3d203c0a1b22",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The number of folds : 26\n",
+      "The length of paper needed to reach the Moon is : 754585377082.664 m\n"
+     ]
+    }
+   ],
+   "source": [
+    "# To reach the Mt.Fuji \n",
+    "# Calculate the number of folds \n",
+    "DISTANCE_TO_MTFUJI_M =3776 # meters\n",
+    "initial_thickness = 0.00008 # m \n",
+    "num_folds_mt_fuji = folds_to_exceed_height(DISTANCE_TO_MTFUJI_M,initial_thickness)\n",
+    "print(f\"The number of folds : {num_folds_mt_fuji}\")\n",
+    "#Calculate the required paper length \n",
+    "print(f\"The length of paper needed to reach the Moon is : {required_paper_length(num_folds_mt_fuji, initial_thickness)} m\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee3ea91b-66f2-4e2c-ba07-d359eff92608",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 149,
+   "id": "c326c8ca-d367-4cac-886c-66c0797da51b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The number of folds : 26\n",
+      "The length of paper needed to the stars closest to the Sun (Alpha Centauri) is : 754585377082.664 m\n"
+     ]
+    }
+   ],
+   "source": [
+    "# To reach  the stars closest to the Sun that is Alpha Centauri\n",
+    "# Calculate the number of folds \n",
+    "DISTANCE_TO_CENTAURI_M =4.0175 * 10**16 # meters\n",
+    "initial_thickness = 0.00008 # m \n",
+    "num_folds_proxima_centauri = folds_to_exceed_height(DISTANCE_TO_MTFUJI_M,initial_thickness)\n",
+    "print(f\"The number of folds : {num_folds_proxima_centauri}\")\n",
+    "#Calculate the required paper length \n",
+    "print(f\"The length of paper needed to the stars closest to the Sun (Alpha Centauri) is : {required_paper_length(num_folds_proxima_centauri, initial_thickness)} m\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| Ready | Feature | No |

## Problem

- Calculate the minimum number of paper folds required to exceed the height of Mt. Fuji.
- Extend the calculation to determine the number of folds needed for various celestial distances.

## Solution

- Introduced a Jupyter notebook that contains markdown and code cells to perform the calculations.
- Developed a function to compute the number of folds required for arbitrary heights.
- Implemented calculations using Python 3, loops, and the math library.

## Test results

_Add your screenshots or recording about testing_

## Other changes

- None

## Deploy Notes

There are no new dependencies, scripts, or environment variables introduced with this PR.